### PR TITLE
Update gbt7714-numerical.bst to v2.1.7

### DIFF
--- a/2024山大本科毕设模板/gbt7714-numerical.bst
+++ b/2024山大本科毕设模板/gbt7714-numerical.bst
@@ -8,9 +8,9 @@
 %% -------------------------------------------------------------------
 %% GB/T 7714 BibTeX Style
 %% https://github.com/zepinglee/gbt7714-bibtex-style
-%% Version: 2022/10/03 v2.1.5
+%% Version: 2025/03/11 v2.1.7
 %% -------------------------------------------------------------------
-%% Copyright (C) 2016--2022 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016--2025 by Zeping Lee <zepinglee AT gmail.com>
 %% -------------------------------------------------------------------
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
@@ -39,6 +39,7 @@ INTEGERS {
   show.medium.type
   short.journal
   italic.journal
+  link.journal
   bold.journal.volume
   show.missing.address.publisher
   space.before.pages
@@ -73,19 +74,20 @@ FUNCTION {load.config}
   #1 'title.in.journal :=
   #0 'show.patent.country :=
   #1 'show.mark :=
-  #1 'space.before.mark :=
-  #0 'show.medium.type :=
-  "none" 'component.part.label :=
+  #0 'space.before.mark :=
+  #1 'show.medium.type :=
+  "slash" 'component.part.label :=
   #0 'short.journal :=
   #0 'italic.journal :=
+  #0 'link.journal :=
   #0 'bold.journal.volume :=
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
   #0 'wave.dash.in.pages :=
-  #0 'show.urldate :=
-  #0 'show.url :=
-  #0 'show.doi :=
+  #1 'show.urldate :=
+  #1 'show.url :=
+  #1 'show.doi :=
   #1 'show.preprint :=
   #0 'show.note :=
   #0 'show.english.translation :=
@@ -131,7 +133,7 @@ ENTRY
     year
   }
   { entry.lang entry.is.electronic is.pure.electronic entry.numbered }
-  { label extra.label sort.label short.label short.list entry.mark entry.url }
+  { label extra.label sort.label short.list entry.mark entry.url }
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block after.slash }
 
@@ -735,7 +737,7 @@ FUNCTION {editor.full}
 
 FUNCTION {make.full.names}
 { type$ "book" =
-  type$ "inbook" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.full
     { type$ "collection" =
@@ -1057,7 +1059,7 @@ FUNCTION {get.journal.title}
 }
 
 FUNCTION {check.arxiv.preprint}
-{ #1 #5 substring$ "l" change.case$ "arxiv" =
+{ #1 #5 substring$ purify$ "l" change.case$ "arxiv" =
     { #1 }
     { #0 }
   if$
@@ -1068,6 +1070,10 @@ FUNCTION {format.journal}
   duplicate$ empty$ not
     { italic.journal entry.lang lang.en = and
         'emphasize
+        'skip$
+      if$
+      link.journal
+        'add.link
         'skip$
       if$
     }
@@ -1298,7 +1304,7 @@ FUNCTION {extract.after.slash}
 
 FUNCTION {format.year}
 { year empty$ not
-    { year extract.before.slash extra.label * }
+    { year extra.label * }
     { date empty$ not
         { date extract.before.dash extra.label * }
         { entry.is.electronic not
@@ -1478,7 +1484,7 @@ FUNCTION {format.periodical.year.volume.number}
 
 FUNCTION {check.url}
 { url empty$ not
-    { "\url{" url * "}" * 'entry.url :=
+    { url 'entry.url :=
       #1 'entry.is.electronic :=
     }
     { howpublished empty$ not
@@ -1509,7 +1515,11 @@ FUNCTION {output.url}
 { show.url is.pure.electronic or
   entry.url empty$ not and
     { new.block
-      entry.url output
+      entry.url #1 #5 substring$ "\url{" =
+        { entry.url }
+        { "\url{" entry.url * "}" * }
+      if$
+      output
     }
     'skip$
   if$
@@ -1529,8 +1539,8 @@ FUNCTION {is.in.url}
     { entry.url empty$
         { #0 }
         { s text.length$ 'len :=
-          entry.url text.length$ 'charptr :=
-            { entry.url charptr len substring$ s = not
+          entry.url "l" change.case$ text.length$ 'charptr :=
+            { entry.url "l" change.case$ charptr len substring$ s "l" change.case$ = not
               charptr #0 >
               and
             }
@@ -1966,6 +1976,10 @@ FUNCTION {preprint}
   format.urldate "" output.after
   output.eprint
   output.url
+  show.preprint not eprint empty$ or
+    'output.doi
+    'skip$
+  if$
   new.block
   format.note output
   fin.entry
@@ -1982,10 +1996,10 @@ FUNCTION {misc}
     { pop$
       booktitle empty$ not
         'incollection
-        { publisher empty$ not
-            'monograph
-            { eprint empty$ not archivePrefix empty$ not or
-                'preprint
+        { eprint empty$ not archivePrefix empty$ not or
+            'preprint
+            { publisher empty$ not
+                'monograph
                 { entry.is.electronic
                     'electronic
                     {
@@ -2030,7 +2044,12 @@ FUNCTION {dataset}
   electronic
 }
 
-FUNCTION {inbook} { book }
+FUNCTION {inbook} {
+  booktitle empty$
+    'book
+    'incollection
+  if$
+}
 
 FUNCTION {inproceedings}
 { "C" set.entry.mark
@@ -2183,7 +2202,6 @@ FUNCTION {format.lab.name}
 
 FUNCTION {format.lab.names}
 { 's :=
-  s #1 format.lab.name 'short.label :=
   #1 'nameptr :=
   s num.names$ 'numnames :=
   ""
@@ -2269,9 +2287,8 @@ FUNCTION {editor.key.organization.label}
 }
 
 FUNCTION {calc.short.authors}
-{ "" 'short.label :=
-  type$ "book" =
-  type$ "inbook" =
+{ type$ "book" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.key.label
     { type$ "collection" =
@@ -2287,10 +2304,6 @@ FUNCTION {calc.short.authors}
     }
   if$
   'short.list :=
-  short.label empty$
-    { short.list 'short.label := }
-    'skip$
-  if$
 }
 
 FUNCTION {calc.label}
@@ -2312,16 +2325,6 @@ FUNCTION {calc.label}
   if$
   *
   'label :=
-  short.label
-  "("
-  *
-  format.year duplicate$ empty$
-  short.list key field.or.null = or
-     { pop$ "" }
-     'skip$
-  if$
-  *
-  'short.label :=
 }
 
 INTEGERS { seq.num }


### PR DESCRIPTION
将GB/T 7714 BibTeX样式升级至2.1.7版本，更正了会议论文没有按照GB/T 7714要求使用//符号析出的问题